### PR TITLE
Add offset to response after linear fit

### DIFF
--- a/src/lib/signalProcess.py
+++ b/src/lib/signalProcess.py
@@ -93,7 +93,7 @@ def subtractLinFit(t, signal: np.ndarray, offset: bool = True, **kwargs) -> np.n
 def getBaseResp(signal: np.ndarray, t: np.ndarray, 
                 t_base: tuple[float,float] = (2.2,2.9),
                 t_resp: tuple[float,float] = (3.0,3.15),
-                negResp: bool = True,
+                negResp: bool = False,
                 **kwargs) -> tuple[float,float]:
     """
     Extract average signal at t_base and max signal between t_resp.
@@ -107,7 +107,7 @@ def getBaseResp(signal: np.ndarray, t: np.ndarray,
                                 - 'True': Response with max absolute value is returned, whether positive or negative.
                                           Orginal sign of the response is preserved.
                                 - 'False': Only max positive response is returned.
-                                Defaults to 'True'.
+                                Defaults to 'False'.
         **kwargs: Optional arguments that will override default.
 
     Returns:

--- a/src/lib/signalProcess.py
+++ b/src/lib/signalProcess.py
@@ -75,6 +75,8 @@ def subtractLinFit(t, signal: np.ndarray, offset: bool = True, **kwargs) -> np.n
     Returns:
         filtered_signal (numpy array): signal array after removal of linear fit
     """
+    # Optionally override parameters using kwargs
+    offset = kwargs.get('offset',offset)
     
     X = np.vstack([t, np.ones(len(t))]).T
     slope,intercept = np.linalg.lstsq(X,signal, rcond=None)[0]
@@ -211,7 +213,7 @@ def pkDFFimg(imgSeries: np.ndarray,
     
     # whether to subtract fitted line
     if subLinFit:
-        signal = subtractLinFit(t,signal)[0]
+        signal = subtractLinFit(t, signal, **kwargs)[0]
 
     # whether to apply low pass filter
     if butterFilt:


### PR DESCRIPTION
Add offset to response after linear fit in function 'subtractLinFit' to correct dFF. Add optional arguments 'negResp', 'absResp', 'dFResp' in functions 'getBaseResp' and 'pkDFFimg' to allow more flexible calculation of absolute negative response and dF.